### PR TITLE
Subscribe to websocket messages and publish to MQTT

### DIFF
--- a/server.js
+++ b/server.js
@@ -76,6 +76,8 @@ if (MQTT_ENABLED) {
     );
 
     await mqttManager.connect();
+
+    wsManager.subscribe("EVENT_APO_STATE", (response) => mqttManager.publish('anova-oven-forwarder', response));
 }
 
 if (API_SERVER_ENABLED) {


### PR DESCRIPTION
Tried a few months ago to get this working publishing to MQTT, and realised it was missing subscribe / publish calls.

Tested locally, pushes to a Mosquitto instance with no problems

(Unrelated: also managed to consume messages in Node RED and Home assistant, and even turn off the oven at the end of a cook.  So cool!  Thanks again for a great project :) ) 